### PR TITLE
lag MTU setting fix - fix for #18695

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2208,7 +2208,6 @@ def add_portchannel(ctx, portchannel_name, min_links, fallback, fast_rate):
 
     fvs = {
         'admin_status': 'up',
-        'mtu': '9100',
         'lacp_key': 'auto',
         'fast_rate': fast_rate.lower(),
     }
@@ -2333,16 +2332,19 @@ def add_portchannel_member(ctx, portchannel_name, port_name):
 
         # Dont allow a port to be member of port channel if its MTU does not match with portchannel
         portchannel_entry =  db.get_entry('PORTCHANNEL', portchannel_name)
-        if portchannel_entry and portchannel_entry.get(PORT_MTU) is not None :
+        if portchannel_entry:
             port_entry = db.get_entry('PORT', port_name)
-
             if port_entry and port_entry.get(PORT_MTU) is not None:
                 port_mtu = port_entry.get(PORT_MTU)
-
-                portchannel_mtu = portchannel_entry.get(PORT_MTU) # TODO: MISSING CONSTRAINT IN YANG MODEL
-                if portchannel_mtu != port_mtu:
-                    ctx.fail("Port MTU of {} is different than the {} MTU size"
-                             .format(port_name, portchannel_name))
+                portchannel_mtu = portchannel_entry.get(PORT_MTU)                
+                # If portchannel MTU is not set, set it to the first port MTU
+                if not portchannel_mtu:
+                    portchannel_mtu = port_mtu
+                    db.mod_entry('PORTCHANNEL', portchannel_name, {PORT_MTU: port_mtu})
+                
+                if (not isinstance(portchannel_mtu, type(port_mtu))) or (portchannel_mtu != port_mtu):  # TODO: MISSING CONSTRAINT IN YANG MODEL
+                    ctx.fail("Port MTU of {} is different than the {} MTU size "
+                             .format(port_name, portchannel_name))                    
 
         # Dont allow a port to be member of port channel if its TPID is not at default 0x8100
         # If TPID is supported at LAG level, when member is added, the LAG's TPID is applied to the
@@ -2403,6 +2405,11 @@ def del_portchannel_member(ctx, portchannel_name, port_name):
 
     try:
         db.set_entry('PORTCHANNEL_MEMBER', portchannel_name + '|' + port_name, None)
+        # If this was the last port in the portchannel, set the portchannel MTU to None
+        portchannel_list = db.get_table(CFG_PORTCHANNEL_PREFIX)
+        if (portchannel_list is None) or (portchannel_list == {}):
+            db.mod_entry('PORTCHANNEL', portchannel_name, {PORT_MTU: None})
+            
     except JsonPatchConflict:
         ctx.fail("Invalid or nonexistent portchannel or interface. Please ensure existence of portchannel member.")
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix for [#18695](https://github.com/sonic-net/sonic-buildimage/issues/18695)
#### How I did it
When creating PortChannel, don't set MTU
MTU is set according to first port inserted to PortChannel.
When last port is removed, set PortChannel MTU back to None
#### How to verify it
Not tested yet
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

